### PR TITLE
Fix listview issue

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -60,7 +60,11 @@ function getInstruments(){
 				+ instrumentname 
 				+ '</a></li>').enhanceWithin();
 		}
-		$("#instruments").listview("refresh");
+		try {
+		    $('#instruments').listview('refresh');
+		} catch(e) {
+		     $('#instruments').listview();
+		}
 		$.mobile.loading( 'hide');
 	});
 }


### PR DESCRIPTION
listview("refresh") threw errors because the list #instruments had not been initialised.  This change checks for the error and displays #instruments as a new list, if necessary.
I know this line didn't cause errors in the past.  I believe the error now occurs because of some sort of update to jquery.